### PR TITLE
Fix admin redirect path

### DIFF
--- a/web/common.js
+++ b/web/common.js
@@ -32,7 +32,7 @@
   }
 
   function requireAdmin(){
-    if (getRole() !== 'admin') location.replace('accueil.html');
+    if (getRole() !== 'admin') location.replace('Accueil.html');
   }
 
   // Expose minimal API globale


### PR DESCRIPTION
## Summary
- update the admin guard redirect to use `Accueil.html`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c846a05abc8323b86d63c37d87ff4f