### PR TITLE
Renforce la protection des pages admin

### DIFF
--- a/web/common.js
+++ b/web/common.js
@@ -78,7 +78,12 @@
     if (here.startsWith('admin-')) {
       const isAdmin = (getRole() || '').toLowerCase() === 'admin';
       const isPlayersAdmin = here === 'admin-joueurs.html';
-      
+
+      if (!isAdmin && !isPlayersAdmin) {
+        toast('Accès réservé aux administrateurs.');
+        location.replace('Accueil.html');
+        return;
+      }
     }
 })();
 


### PR DESCRIPTION
## Summary
- redirige les membres non-admin des pages d’administration vers Accueil.html
- affiche un message d’erreur lors d’un accès refusé à une page admin réservée

## Testing
- node - <<'NODE' … (simulation d’un membre sur Admin-Utilisateurs)


------
https://chatgpt.com/codex/tasks/task_e_68c846c23ff48323850d0a11d57c37fe