### PR TITLE
Simplify login flow without handoff

### DIFF
--- a/web/login.html
+++ b/web/login.html
@@ -266,7 +266,7 @@ function goAfterLogin(role){
   });
 })();
 
-/* Soumission + handoff multi-appareil, AVEC attente serveur prêt avant redirection */
+/* Soumission simple avec attente serveur prêt avant redirection */
 document.getElementById('f').addEventListener('submit', async (e)=>{
   e.preventDefault();
   showErr(''); showBoot(''); setBusy(true);
@@ -275,91 +275,38 @@ document.getElementById('f').addEventListener('submit', async (e)=>{
   const password=document.getElementById('pwd').value||'';
   if(email && !email.includes('@')) email = email+'@gz.local';
 
-  // bouton de “force” si handoff bloque trop
-  let forceBtn;
-  function showForce(){
-    if(forceBtn) return;
-    forceBtn = document.createElement('button');
-    forceBtn.type = 'button';
-    forceBtn.className = 'btn';
-    forceBtn.style.marginTop = '10px';
-    forceBtn.textContent = "C'est moi — connecter ici";
-    forceBtn.onclick = doLogin; // on relance la tentative directe
-    document.querySelector('.footer')?.appendChild(forceBtn);
+  try{
+    const r=await safeFetch(getAPI()+'/auth/login', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({email,password})
+    }, 12000);
+
+    const d=await r.json().catch(()=>({}));
+    if(!r || !r.ok){ throw new Error((d&&d.error)||'Identifiants invalides'); }
+
+    const token=d.token;
+    const role=(d.user&&d.user.role)||'member';
+    const expHours = Number(d.expHours||1);
+    localStorage.setItem('efoot.token', token);
+    localStorage.setItem('efoot.role', role.toLowerCase());
+    localStorage.setItem('efoot.expAt', String(Date.now()+expHours*60*1000));
+
+    // <— NOUVEAU : on attend que l’API soit prête avant de quitter la page
+    showBoot('Connexion réussie. Le serveur se réveille…');
+    const ok = await waitForHealth(getAPI(), 90000);
+    if(!ok){ showErr("Le serveur est lent à démarrer (Render). Patiente et réessaie."); setBusy(false); showBoot(''); return; }
+
+    // on valide le token et on part
+    const vr = await validateSession();
+    if(vr){ showBoot(''); goAfterLogin(vr); }
+    else { showErr("Impossible de valider la session pour l’instant."); setBusy(false); showBoot(''); }
+
+  }catch(err){
+    console.error(err);
+    showErr(err.message||'Erreur réseau');
+    setBusy(false); showBoot('');
   }
-
-  const doLogin = async ()=>{
-    try{
-      const r=await safeFetch(getAPI()+'/auth/login', {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({email,password})
-      }, 12000);
-
-      if(r && r.status===409){
-        const d=await r.json().catch(()=>({}));
-        showErr("Une autre session est active. Validation requise sur l'autre appareil…");
-        setTimeout(showForce, 6000);
-        if(d && d.request_id && d.nonce){
-          const poll = async ()=>{
-            try{
-              const rr=await safeFetch(getAPI()+`/auth/handoff/status?request_id=${encodeURIComponent(d.request_id)}&nonce=${encodeURIComponent(d.nonce)}`,{},8000);
-              const dd=await rr.json();
-              if(dd.status==='approved' && dd.token){
-                const role=(dd.user&&dd.user.role)||'member';
-                localStorage.setItem('efoot.token', dd.token);
-                localStorage.setItem('efoot.role', role.toLowerCase());
-                localStorage.setItem('efoot.expAt', String(Date.now()+Number(dd.expHours||24)*3600*1000));
-                // attendre serveur prêt puis /auth/me
-                showBoot('Connexion approuvée. Préparation du serveur…');
-                const ok = await waitForHealth(getAPI(), 90000);
-                if(ok){
-                  const vr = await validateSession();
-                  if(vr){ showBoot(''); goAfterLogin(vr); return; }
-                }
-                showErr("Le serveur est lent à démarrer. Réessaie dans quelques secondes.");
-                setBusy(false); showBoot(''); return;
-              }
-              if(dd.status==='denied'){ showErr('Connexion refusée depuis l’autre appareil.'); setBusy(false); return; }
-              if(dd.status==='expired'){ showErr('Demande expirée. Recommencez.'); setBusy(false); return; }
-              setTimeout(poll, 1800);
-            }catch(_){ setTimeout(poll, 2200); }
-          };
-          poll();
-        }else{
-          setBusy(false);
-        }
-        return;
-      }
-
-      const d=await r.json().catch(()=>({}));
-      if(!r || !r.ok){ throw new Error((d&&d.error)||'Identifiants invalides'); }
-
-      const token=d.token;
-      const role=(d.user&&d.user.role)||'member';
-      const expHours = Number(d.expHours||1);
-      localStorage.setItem('efoot.token', token);
-      localStorage.setItem('efoot.role', role.toLowerCase());
-      localStorage.setItem('efoot.expAt', String(Date.now()+expHours*60*1000));
-
-      // <— NOUVEAU : on attend que l’API soit prête avant de quitter la page
-      showBoot('Connexion réussie. Le serveur se réveille…');
-      const ok = await waitForHealth(getAPI(), 90000);
-      if(!ok){ showErr("Le serveur est lent à démarrer (Render). Patiente et réessaie."); setBusy(false); showBoot(''); return; }
-
-      // on valide le token et on part
-      const vr = await validateSession();
-      if(vr){ showBoot(''); goAfterLogin(vr); }
-      else { showErr("Impossible de valider la session pour l’instant."); setBusy(false); showBoot(''); }
-
-    }catch(err){
-      console.error(err);
-      showErr(err.message||'Erreur réseau');
-      setBusy(false); showBoot('');
-    }
-  };
-
-  doLogin();
 });
 
 /* ===== Config API ===== */


### PR DESCRIPTION
## Summary
- replace the handoff-oriented login handler with a single fetch to `/auth/login`
- keep token storage, server readiness wait, and validation while removing multi-session messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c93d44fc408323aba9f0912d5e752d