### PR TITLE
Simplify login session handling

### DIFF
--- a/api/test_db.js
+++ b/api/test_db.js
@@ -22,7 +22,6 @@ const pool = new Pool({
       'matchday',
       'draft',
       'sessions',
-      'handoff_requests',
       'season_totals',
       'champion_result'
     ];

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -73,19 +73,6 @@ CREATE INDEX IF NOT EXISTS sessions_user_active
   ON sessions(user_id)
   WHERE is_active;
 
--- Demandes de transfert d'une session vers un nouvel appareil
-CREATE TABLE IF NOT EXISTS handoff_requests (
-  id          TEXT PRIMARY KEY,
-  user_id     INTEGER REFERENCES users(id) ON DELETE CASCADE,
-  nonce       TEXT NOT NULL,
-  new_device  TEXT,
-  created_at  TIMESTAMPTZ DEFAULT now(),
-  status      TEXT NOT NULL DEFAULT 'pending', -- pending | approved | denied | expired
-  approved_at TIMESTAMPTZ,
-  denied_at   TIMESTAMPTZ,
-  consumed_at TIMESTAMPTZ
-);
-
 -- Table optionnelle pour l'ancien suivi cumulé de la saison
 CREATE TABLE IF NOT EXISTS season_totals (
   id         SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- always issue a fresh session on login, revoking prior ones and returning a consistent 24h token payload
- remove handoff-related code paths and schema artifacts no longer used by the API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c93d1934b483239f843ee7d360143c